### PR TITLE
Update README to reference `deno install` (fixes #7)

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,7 @@
+Copyright 2021 Dylan Pyle and other contributors: https://github.com/dylanpyle/version/graphs/contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -7,26 +7,32 @@ A simple semantic versioning tool — a lightweight replacement for `npm version
 
 — the rest is up to you.
 
-## Usage
+## Installation
 
 ```
-# Create a `VERSION` file
-$ deno run -A https://deno.land/x/version/index.ts init
-
-# Increment a version
-$ deno run -A https://deno.land/x/version/index.ts patch
-$ deno run -A https://deno.land/x/version/index.ts minor
-$ deno run -A https://deno.land/x/version/index.ts major
-
-# Explicitly set a specific version
-$ deno run -A https://deno.land/x/version/index.ts set 1.2.3
-
-# Print out the current version if it exists
-$ deno run -A https://deno.land/x/version/index.ts get
+$ deno install -n version -r -A https://deno.land/x/version/index.ts
 ```
 
 Note: If you don't use `-A`, `--allow-read` and `--allow-write` are needed for
 managing the `VERSION` file and `--allow-run` for Git actions.
+
+## Usage
+
+```
+# Create a `VERSION` file
+$ version init
+
+# Increment a version
+$ version patch
+$ version minor
+$ version major
+
+# Explicitly set a specific version
+$ version set 1.2.3
+
+# Print out the current version if it exists
+$ version get
+```
 
 ## License
 


### PR DESCRIPTION
Also added the license text, apparently that was a blank file. Oops!