### PR TITLE
Add ability to see incremented version

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,8 +69,27 @@ async function run() {
     }
 
     case "get": {
+      const [release] = params
       const currentVersion = await readVersion();
-      console.log(currentVersion);
+      if (release) {
+        switch (release) {
+          case "major":
+          case "minor":
+          case "patch": {
+            const newVersion = inc(
+              currentVersion,
+              release
+            )
+            if (!newVersion) {
+              throw new Error("Could not increment version");
+            }
+            console.log(newVersion)
+            break;
+          }
+        }
+      } else {
+        console.log(currentVersion);
+      }
       break;
     }
 

--- a/index.ts
+++ b/index.ts
@@ -52,6 +52,12 @@ enum Actions {
   get = "get",
 }
 
+enum GetSubActions {
+  major = "major",
+  minor = "minor",
+  patch = "patch",
+}
+
 const allowedActions = Object.keys(Actions);
 
 async function run() {
@@ -72,23 +78,20 @@ async function run() {
       const [release] = params
       const currentVersion = await readVersion();
       if (release) {
-        switch (release) {
-          case "major":
-          case "minor":
-          case "patch": {
-            const newVersion = inc(
-              currentVersion,
-              release
-            )
-            if (!newVersion) {
-              throw new Error("Could not increment version");
-            }
-            console.log(newVersion)
-            break;
-          }
+        const allowedSubActions = Object.keys(GetSubActions);
+        if (!allowedSubActions.includes(release)) {
+          throw new UserError(`Usage: version get <${allowedSubActions.join("|")}>?`);
         }
+        const newVersion = inc(
+          currentVersion,
+          release as GetSubActions
+        )
+        if (!newVersion) {
+          throw new Error("Could not increment version");
+        }
+        console.log(newVersion)
       } else {
-        console.log(currentVersion);
+        console.log(currentVersion)
       }
       break;
     }

--- a/readme.md
+++ b/readme.md
@@ -32,11 +32,14 @@ $ version major
 $ version set 1.2.3
 
 # Print out the current version if it exists
-$ version get
+$ version get # 1.2.3
+
+# Print out the future version, without making any changes
+$ version get minor # 1.3.0
 ```
 
-If you prefer not to install the CLI locally, just substitute `$ version
-[whatever]` with:
+If you prefer not to install the CLI locally, just substitute
+`$ version [whatever]` with:
 
 ```
 $ deno run -A https://deno.land/x/version/index.ts [whatever]


### PR DESCRIPTION
This adds the ability to get the incremented version without making any changes. Allows scripts to update other files other than the `VERSION` file before committing.

```sh
version get # 1.2.3
version get patch # 1.2.4
version get minor # 1.3.0
version get major # 2.0.0
```

Fixes https://github.com/dylanpyle/version/issues/15