### PR TITLE
Clean spaces and new lines while reading VERSION

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ async function readVersion(): Promise<string> {
 
   try {
     content = await Deno.readTextFile(fileName);
+    content = content.replace(/[\n\r\t\s]+/g, '');
   } catch (err) {
     if (err instanceof Deno.errors.PermissionDenied) {
       throw err;
@@ -19,7 +20,7 @@ async function readVersion(): Promise<string> {
       );
     }
   }
-
+  
   if (!valid(content)) {
     throw new UserError(
       `${fileName} file contained "${content}", which is not a valid version string`,

--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,7 @@ async function readVersion(): Promise<string> {
       );
     }
   }
-  
+
   if (!valid(content)) {
     throw new UserError(
       `${fileName} file contained "${content}", which is not a valid version string`,


### PR DESCRIPTION
IDEs usually add end of file with a new line, when you open the file. This is creating an issue for VERSIONing.